### PR TITLE
Load polyfill from polyfill.io

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9,5 +9,5 @@ title: Reference
 <p>You can also <a href="{{'/guides/syntax.html' | relative_url }}">learn about the syntax</a>, <a href="{{'/guides/syntax.html#examples-' | relative_url }}">look at some examples</a>, <a href="{{'/guides/atomic-classes.html' | relative_url }}">learn about custom classes</a>, or <a href="{{'/guides/helper-classes.html' | relative_url }}">learn about helper/utility classes</a>.  There is also <a href="{{'/guides/atomizer.html#web-tools' | relative_url }}">a handy web tool</a> to help you experiment with Atomizer syntax.</p>
 <div id="reference-app"></div>
 
-<script type="application/javascript" src="https://polyfills.yahooapis.com/polyfill.js?features=es5&version=2.1.21"></script>
+<script type="application/javascript" src="https://polyfill.io/v3/polyfill.min.js?features=es5"></script>
 <script src="{{'/assets/js/main.js' | relative_url }}"></script>


### PR DESCRIPTION
Seems like `https://polyfills.yahooapis.com/polyfill.js?features=es5&version=2.1.21` is down, and it blocks the client side javascript being executed. Changing to load the polyfill from `polyfill.io`

Btw, did we build the site manually? 

https://github.com/acss-io/acss-site/issues/128

@src-code @tom76kimo @redonkulus 